### PR TITLE
Cross-build for sbt 1.x and sbt 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -62,23 +62,22 @@ jobs:
       fail-fast: false
       matrix:
         jdk:
-          - 11
           - 17
           - 21
           - 25
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: liberica:${{ matrix.jdk }}
           apps: sbt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -41,12 +41,12 @@ jobs:
         uses: alejandrohdezma/actions/check-semver-tag@v1
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
-          jvm: liberica:11
+          jvm: liberica:17
           apps: sbt
 
       - name: Run `sbt ci-publish`
@@ -65,17 +65,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: main
           ssh-key: ${{ secrets.GIT_DEPLOY_KEY }}
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: liberica:17
           apps: sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / scalaVersion           := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization           := "com.alejandrohdezma"
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; +versionPolicyCheck; +publishLocal; +sbt-propagate/scripted; mdoc")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
-ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
-ThisBuild / organization                  := "com.alejandrohdezma"
-ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
-ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
+ThisBuild / scalaVersion           := _root_.scalafix.sbt.BuildInfo.scala212
+ThisBuild / organization           := "com.alejandrohdezma"
+ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; scripted")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
@@ -14,6 +13,8 @@ lazy val documentation = project
 
 lazy val `sbt-propagate` = module
   .enablePlugins(SbtPlugin)
+  .settings(crossScalaVersions := Seq(scalaVersion.value, "3.8.4"))
+  .settings(pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.12.12").getOrElse("2.0.0"))
   .settings(scriptedBatchExecution := false)
   .settings(scriptedBufferLog := false)
   .settings(scriptedLaunchOpts += s"-Dplugin.version=${version.value}")

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion           := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization           := "com.alejandrohdezma"
 ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 
-addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; scripted")
+addCommandAlias("ci-test", "fix --check; +versionPolicyCheck; +publishLocal; +sbt-propagate/scripted; mdoc")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 

--- a/modules/sbt-propagate/src/main/scala/com/alejandrohdezma/sbt/propagate/ResourceGeneratorPlugin.scala
+++ b/modules/sbt-propagate/src/main/scala/com/alejandrohdezma/sbt/propagate/ResourceGeneratorPlugin.scala
@@ -52,7 +52,7 @@ object ResourceGeneratorPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def projectSettings: Seq[Setting[_]] = List(
+  override def projectSettings = List(
     libraryDependencies                    += "com.alejandrohdezma" %% "resource-generator" % BuildInfo.version,
     resourcesToPropagateDescriptionScraper := Map(
       "md" -> (_.takeWhile(_.startsWith("[comment]: <>")).map(_.stripPrefix("[comment]: <> (").stripSuffix(")"))),
@@ -80,7 +80,7 @@ object ResourceGeneratorPlugin extends AutoPlugin {
 
       IO.write(properties, "Metadata for sbt-propagate SBT plugin", file)
 
-      List(file)
+      Seq(file)
     }.taskValue,
     Compile / resourceGenerators += Def.task {
       resourcesToPropagate.value.map { case (resource, destination) =>
@@ -91,7 +91,7 @@ object ResourceGeneratorPlugin extends AutoPlugin {
         IO.copyFile(file(resource), resourceFile)
 
         resourceFile
-      }
+      }: Seq[File]
     }.taskValue
   )
 

--- a/modules/sbt-propagate/src/main/scala/com/alejandrohdezma/sbt/propagate/ResourceGeneratorPlugin.scala
+++ b/modules/sbt-propagate/src/main/scala/com/alejandrohdezma/sbt/propagate/ResourceGeneratorPlugin.scala
@@ -21,9 +21,9 @@ import java.util.Properties
 import sbt.Keys._
 import sbt._
 
-/** This plugin copies the resources listed in `resourcesToPropagate` to `target/resources-to-propagate` and adds that
-  * folder as a resources directory. It also creates a `resource-generator-metadata.properties` containing the name of
-  * the propagated resources that is then picked-up by `ResourceGenerator` to generate the results.
+/** This plugin copies the resources listed in `resourcesToPropagate` into the managed resources directory so they are
+  * packaged into the artifact. It also creates a `resource-generator-metadata.properties` containing the name of the
+  * propagated resources that is then picked-up by `ResourceGenerator` to generate the results.
   *
   * It also provides a `resourcesToPropagateDocs` setting that contains the same elements as `resourcesToPropagate` but
   * including each file's description.
@@ -69,10 +69,9 @@ object ResourceGeneratorPlugin extends AutoPlugin {
 
       (resource, destination, description.mkString("\n"))
     },
-    resourcesToPropagate                   := Nil,
-    Compile / unmanagedResourceDirectories += target.value / "resources-to-propagate",
-    Compile / resourceGenerators           += Def.task {
-      val file = target.value / "resources-to-propagate" / "resource-generator-metadata.properties"
+    resourcesToPropagate         := Nil,
+    Compile / resourceGenerators += Def.task {
+      val file = (Compile / resourceManaged).value / "resource-generator-metadata.properties"
 
       val properties = new Properties()
 
@@ -84,7 +83,7 @@ object ResourceGeneratorPlugin extends AutoPlugin {
     }.taskValue,
     Compile / resourceGenerators += Def.task {
       resourcesToPropagate.value.map { case (resource, destination) =>
-        val resourceFile = target.value / "resources-to-propagate" / destination
+        val resourceFile = (Compile / resourceManaged).value / destination
 
         streams.value.log.info(s"Copying $resource to $resourceFile")
 

--- a/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/build.sbt
+++ b/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/build.sbt
@@ -1,6 +1,10 @@
 ThisBuild / publish / skip := true
-enablePlugins(MdocPlugin)
-mdocVariables += "PROPAGATED_RESOURCES" -> propagatedResouces.value
+
+lazy val root = (project in file("."))
+  .enablePlugins(MdocPlugin)
+  .aggregate(example)
+  .settings(mdocOut := baseDirectory.value / "target" / "mdoc")
+  .settings(mdocVariables += "PROPAGATED_RESOURCES" -> propagatedResouces.value)
 
 lazy val example = project
   .settings(publish / skip := false)
@@ -9,7 +13,7 @@ lazy val example = project
   .settings(scriptedBufferLog := false)
   .settings(scriptedLaunchOpts += s"-Dplugin.version=${version.value}")
   .enablePlugins(ResourceGeneratorPlugin)
-  .settings(resourcesToPropagateDescriptionScraper += "xml" -> { lines: List[String] =>
+  .settings(resourcesToPropagateDescriptionScraper += "xml" -> { (lines: List[String]) =>
     lines.drop(1).takeWhile(_.startsWith("<!--")).map(_.stripPrefix("<!-- ").stripSuffix(" -->"))
   })
   .settings(resourcesToPropagate += "docs-to-propagate/file1.md" -> "docs/propagated/file_1.md")

--- a/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/example/src/main/scala/MyGeneratorPlugin.scala
+++ b/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/example/src/main/scala/MyGeneratorPlugin.scala
@@ -18,7 +18,7 @@ object MyGeneratorPlugin extends sbt.AutoPlugin with ResourceGenerator[(String, 
 
   }
 
-  val generateMyFiles = sbt.taskKey[Unit](s"Generates the following files: ${resources.mkString(", ")}")
+  @transient val generateMyFiles = sbt.taskKey[Unit](s"Generates the following files: ${resources.mkString(", ")}")
 
   override def repository: Option[String] = Some("my-org/my-repo")
 

--- a/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/example/src/sbt-test/example/simple/project/build.properties
+++ b/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/example/src/sbt-test/example/simple/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.12.12

--- a/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/project/build.properties
+++ b/modules/sbt-propagate/src/sbt-test/sbt-propagate/simple/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.12.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("ch.epfl.scala"       % "sbt-scalafix"          % "0.14.7")
 addSbtPlugin("ch.epfl.scala"       % "sbt-version-policy"    % "3.2.1")
-addSbtPlugin("com.alejandrohdezma" % "sbt-ci"                % "3.0.0")
+addSbtPlugin("com.alejandrohdezma" % "sbt-ci"                % "4.0.0")
 addSbtPlugin("com.alejandrohdezma" % "sbt-fix"               % "0.12.0")
 addSbtPlugin("com.alejandrohdezma" % "sbt-github-mdoc"       % "0.13.0")
 addSbtPlugin("com.alejandrohdezma" % "sbt-github-header"     % "0.13.0")


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

This makes `sbt-propagate` cross-build and publish for **both** sbt 1.x (the existing `_2.12_1.0` artifact) and sbt 2.x (a new `_sbt2_3` artifact, on Scala 3.8.4) from a single codebase.

### Build
- The Scala-3 axis is added to the **`sbt-propagate` plugin module only**. `pluginCrossBuild / sbtVersion` keys off the Scala epoch via the sbt-modules `on(2)` helper — sbt **1.12.12** on 2.12, sbt **2.0.0** on 3.8.4.
- The `resource-generator` library (already cross-built to Scala 3) and the `documentation` module are left on their existing axes — a build-wide 3.8.4 axis would be unsatisfiable because `documentation` depends on `resource-generator` (pinned to 3.3.8).
- The sbt 1.x floor rises from `1.2.8` to `1.12.12`: with the per-test `build.properties` removed, `scriptedSbt = pluginCrossBuild / sbtVersion` must boot scripted on the JDK-25 CI lane.

### Source
- The plugin now compiles under Scala 3 / tpolecat `-Werror`: the `projectSettings` return type is dropped (the `_` wildcard is rejected) and the `resourceGenerators` tasks return `Seq[File]` (sbt 2's invariant `Task` won't accept `Task[List[File]]`).
- Propagated resources are written into the **managed resources directory** instead of `target/resources-to-propagate` + an `unmanagedResourceDirectory`. The old setup packaged every file twice (managed + unmanaged), which sbt 2's source-jar packaging rejects with `duplicate entry`. Same JAR paths, packaged once, on both sbt versions.

### Scripted
- The per-test `project/build.properties` are removed so `scriptedSbt` selects the sbt version per axis (sbt 1.x on 2.12, sbt 2.0.0 on 3.8.4).
- The `simple` test is adapted to load and run on sbt 2.0.0 (explicit root project for the mdoc settings, `@transient` on the generated task to opt out of sbt 2 caching, pinned `mdocOut`, parenthesized typed lambda).

### CI
- `sbt-ci` is bumped to **4.0.0** and the workflows are regenerated: this drops the JDK-11 lanes (test matrix → 17/21/25, release → `liberica:17`), which sbt 2.0.0 cannot run on.
- The `ci-test` alias cross-builds with `+`.

### Versioning
- Shipped as a breaking release (`Compatibility.None`): the new `_sbt2_3` axis has no prior artifact and the `projectSettings` signature change trips `versionPolicyCheck`. The release workflow resets the intention afterwards.

> [!NOTE]
> This plugin sets no metadata keys (homepage / licenses / developers / scmInfo), so the usual `URL`→`URI` / `PluginCompat` shim was not needed.
